### PR TITLE
Fix fillval

### DIFF
--- a/include/z5/metadata.hxx
+++ b/include/z5/metadata.hxx
@@ -120,15 +120,19 @@ namespace z5 {
             shape = types::ShapeType(j["shape"].begin(), j["shape"].end());
             chunkShape = types::ShapeType(j["chunks"].begin(), j["chunks"].end());
 
-            const auto fill_value_string = static_cast<std::string>(j["fill_value"]);
-            if (fill_value_string == "NaN") {
-              fillValue = std::numeric_limits<double>::quiet_NaN();
-            } else if (fill_value_string == "Infinity") {
-              fillValue = std::numeric_limits<double>::infinity();
-            } else if (fill_value_string == "-Infinity") {
-              fillValue = -std::numeric_limits<double>::infinity();
+            const auto & fillValJson = j["fill_value"];
+            if(fillValJson.type() == nlohmann::json::value_t::string) {
+                if (fillValJson == "NaN") {
+                    fillValue = std::numeric_limits<double>::quiet_NaN();
+                } else if (fillValJson == "Infinity") {
+                    fillValue = std::numeric_limits<double>::infinity();
+                } else if (fillValJson == "-Infinity") {
+                    fillValue = -std::numeric_limits<double>::infinity();
+                } else {
+                    throw std::runtime_error("Invalid string value for fillValue");
+                }
             } else {
-              fillValue = static_cast<double>(j["fill_value"]);
+                fillValue = static_cast<double>(fillValJson);
             }
 
             const auto & compressionOpts = j["compressor"];

--- a/src/python/module/z5py/dataset.py
+++ b/src/python/module/z5py/dataset.py
@@ -206,7 +206,7 @@ class Dataset:
         copts = json.dumps(copts)
         # get the dataset and write data if necessary
         impl = _z5py.create_dataset(group, name, cls._dtype_dict[parsed_dtype],
-                                    shape, chunks, compression, copts)
+                                    shape, chunks, compression, copts, fillvalue)
         handle = group.get_dataset_handle(name)
         ds = cls(impl, handle, n_threads)
         if have_data:


### PR DESCRIPTION
- fixes fillvalue string handling in c++
- passes fillvalue along to `z5py._create_dataset` in python bindings (was missing before)
- adds python unittest for fillvalue